### PR TITLE
fix error when creating a histogram with unorderable values in python 3

### DIFF
--- a/traces/histogram.py
+++ b/traces/histogram.py
@@ -52,7 +52,7 @@ class Histogram(sortedcontainers.SortedDict):
             result = super(Histogram, self).__setitem__(key, value)
         except TypeError as e:
 
-            if "unorderable" in str(e):
+            if "unorderable" in str(e) or "'<' not supported" in str(e):
                 raise UnorderableElements(e)
 
             if "unhashable" in str(e):


### PR DESCRIPTION
When running the test suite on Python 3, `test_none_handling()` in tests/test_distribution.py fails with `TypeError: '<' not supported between instances of 'NoneType' and 'int'`.

This is caused by the test data (0,1), (None, 0), (2, 0), which Histogram attempts to put in order.  In Python 2, this is possible since `None < x` for a number x is valid (and True), but in Python 3 the comparison raises an exception.

The setter in Histogram tests for unorderable test data by catching `TypeError: unorderable` exceptions.  With Python 3, it's also necessary to catch the similar `TypeError: '<' not supported` exceptions.