### PR TITLE
Added default calculations to TimeSeries.operation()

### DIFF
--- a/traces/timeseries.py
+++ b/traces/timeseries.py
@@ -794,12 +794,14 @@ class TimeSeries(object):
         """
         result = TimeSeries(**kwargs)
         if isinstance(other, TimeSeries):
+            result.default = function(self.default, other.default)
             for time, value in self:
                 result[time] = function(value, other[time])
             for time, value in other:
                 result[time] = function(self[time], value)
         else:
             for time, value in self:
+                result.default = function(self.default, other)
                 result[time] = function(value, other)
         return result
 


### PR DESCRIPTION
I had an issue with using the anding time series with different starting points and default values. i believe the issue was noted by others. This fixed it in my use cases but hasn't been heavily tested