### PR TITLE
Fix conversion of window_size to float breaking timedelta compatiblity

### DIFF
--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -247,6 +247,13 @@ def test_moving_average():
     assert all(pd_ts.values[i] == ts.mean(i - 1, i + 1)
                for i in range(2, 9))
 
+    # Test using timedelta as sampling_period
+    ts = _make_ts(int, time_list, [1, 2, 3, 0])
+    sampling_period = datetime.timedelta(seconds=1)
+    output = dict(ts.moving_average(sampling_period))
+    answer = build_answer(datetime.timedelta(seconds=1), (2, 11))
+    assert output == build_answer(datetime.timedelta(seconds=1), (2, 11))
+
 
 def test_to_bool():
 

--- a/traces/timeseries.py
+++ b/traces/timeseries.py
@@ -434,7 +434,7 @@ class TimeSeries(object):
         )
 
         # convert to datetime if the times are datetimes
-        full_window = float(window_size)
+        full_window = window_size * 1.
         half_window = full_window / 2
         if isinstance(start, datetime.datetime) and not isinstance(
             full_window, datetime.timedelta


### PR DESCRIPTION
With commit 05a14608d06b06dfc589ae9c247d300b89f956b5, using a `timedelta` as `sampling_period` in `moving_average` throws an exception when converting `window_size` to a `float`. Multiplying by `1.` (as previously done) serves the same purpose and still allows `timedelta` to be used.